### PR TITLE
Retry middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ See the `printer` middleware for a more detailed example.
 - [ ] Kafka provider
 - [ ] Google's Pub/Sub
 - [ ] Add protobuf support as a middleware encoder/decoder
-- [ ] Recovery middleware for dealing with panics
+- [x] Recovery middleware for dealing with panics
+- [x] Retry middleware for dealing with unreliable providers/subscribers
 
 ## Example
 

--- a/example/simple/example_test.go
+++ b/example/simple/example_test.go
@@ -26,7 +26,7 @@ func Test_EndToEnd(t *testing.T) {
 		client := pubsub.NewMiddlewareBroker(
 			broker,
 			pubsub.WithPublishInterceptor(printer.PublishInterceptor(writer)),
-			pubsub.WithSubscribeInterceptor(printer.SubscriberInterceptor(writer)),
+			pubsub.WithSubscriberInterceptor(printer.SubscriberInterceptor(writer)),
 		)
 		rx := &lockedCounter{}
 		s := pubsub.NewSubscriber(func(ctx context.Context, m proto.Message) error {

--- a/middleware/recover/recover_test.go
+++ b/middleware/recover/recover_test.go
@@ -58,7 +58,7 @@ func TestSubscribeInterceptor(t *testing.T) {
 			return errors.New("recovery function")
 		}
 
-		interceptor := pubsub.WithSubscribeInterceptor(recover.SubscriberInterceptor(recovery))
+		interceptor := pubsub.WithSubscriberInterceptor(recover.SubscriberInterceptor(recovery))
 		broker = pubsub.NewMiddlewareBroker(broker, interceptor)
 
 		subCalls := 0

--- a/middleware/retry/retry.go
+++ b/middleware/retry/retry.go
@@ -1,0 +1,101 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/botchris/go-pubsub"
+)
+
+// PublishInterceptor adds panic recovery capabilities to publishers.
+func PublishInterceptor(strategy Strategy) pubsub.PublishInterceptor {
+	return func(ctx context.Context, next pubsub.PublishHandler) pubsub.PublishHandler {
+		return func(ctx context.Context, topic pubsub.Topic, m interface{}) (err error) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			done := ctx.Done()
+
+		retry:
+			select {
+			case <-done:
+				return fmt.Errorf("context cancelled")
+			default:
+			}
+
+			if backoff := strategy.Proceed(topic, m); backoff > 0 {
+				select {
+				case <-time.After(backoff):
+					// TODO(stevvooe): This branch holds up the next try. Before, we
+					// would simply break to the "retry" label and then possibly wait
+					// again. However, this requires all retry strategies to have a
+					// large probability of probing the sync for success, rather than
+					// just backing off and sending the request.
+				case <-done:
+					return fmt.Errorf("context cancelled")
+				}
+			}
+
+			if nErr := next(ctx, topic, m); nErr != nil {
+				if strategy.Failure(topic, m, nErr) {
+					fmt.Printf("retrying publish error, cause: message was dropped, retries exhausted {topic=%s, error=%s}\n", topic, nErr)
+
+					return nil
+				}
+
+				goto retry
+			}
+
+			strategy.Success(topic, m)
+
+			return nil
+		}
+	}
+}
+
+// SubscriberInterceptor adds panic recovery capabilities to subscribers.
+func SubscriberInterceptor(strategy Strategy) pubsub.SubscriberInterceptor {
+	return func(ctx context.Context, next pubsub.SubscriberMessageHandler) pubsub.SubscriberMessageHandler {
+		return func(ctx context.Context, s *pubsub.Subscriber, topic pubsub.Topic, m interface{}) (err error) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			done := ctx.Done()
+
+		retry:
+			select {
+			case <-done:
+				return fmt.Errorf("context cancelled")
+			default:
+			}
+
+			if backoff := strategy.Proceed(topic, m); backoff > 0 {
+				select {
+				case <-time.After(backoff):
+					// TODO(stevvooe): This branch holds up the next try. Before, we
+					// would simply break to the "retry" label and then possibly wait
+					// again. However, this requires all retry strategies to have a
+					// large probability of probing the sync for success, rather than
+					// just backing off and sending the request.
+				case <-done:
+					return fmt.Errorf("context cancelled")
+				}
+			}
+
+			if nErr := next(ctx, s, topic, m); nErr != nil {
+				if strategy.Failure(topic, m, nErr) {
+					fmt.Printf("retrying delivery error, cause: message was dropped, retries exhausted {topic=%s, error=%s}\n", topic, nErr)
+
+					return nil
+				}
+
+				goto retry
+			}
+
+			strategy.Success(topic, m)
+
+			return nil
+		}
+	}
+}

--- a/middleware/retry/retry.go
+++ b/middleware/retry/retry.go
@@ -10,8 +10,8 @@ import (
 
 // PublishInterceptor adds panic recovery capabilities to publishers.
 func PublishInterceptor(strategy Strategy) pubsub.PublishInterceptor {
-	return func(ctx context.Context, next pubsub.PublishHandler) pubsub.PublishHandler {
-		return func(ctx context.Context, topic pubsub.Topic, m interface{}) (err error) {
+	return func(_ context.Context, next pubsub.PublishHandler) pubsub.PublishHandler {
+		return func(_ context.Context, topic pubsub.Topic, m interface{}) (err error) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -56,8 +56,8 @@ func PublishInterceptor(strategy Strategy) pubsub.PublishInterceptor {
 
 // SubscriberInterceptor adds panic recovery capabilities to subscribers.
 func SubscriberInterceptor(strategy Strategy) pubsub.SubscriberInterceptor {
-	return func(ctx context.Context, next pubsub.SubscriberMessageHandler) pubsub.SubscriberMessageHandler {
-		return func(ctx context.Context, s *pubsub.Subscriber, topic pubsub.Topic, m interface{}) (err error) {
+	return func(_ context.Context, next pubsub.SubscriberMessageHandler) pubsub.SubscriberMessageHandler {
+		return func(_ context.Context, s *pubsub.Subscriber, topic pubsub.Topic, m interface{}) (err error) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 

--- a/middleware/retry/retry.go
+++ b/middleware/retry/retry.go
@@ -27,7 +27,7 @@ func PublishInterceptor(strategy Strategy) pubsub.PublishInterceptor {
 			if backoff := strategy.Proceed(topic, m); backoff > 0 {
 				select {
 				case <-time.After(backoff):
-					// TODO(stevvooe): This branch holds up the next try. Before, we
+					// TODO: This branch holds up the next try. Before, we
 					// would simply break to the "retry" label and then possibly wait
 					// again. However, this requires all retry strategies to have a
 					// large probability of probing the sync for success, rather than
@@ -73,7 +73,7 @@ func SubscriberInterceptor(strategy Strategy) pubsub.SubscriberInterceptor {
 			if backoff := strategy.Proceed(topic, m); backoff > 0 {
 				select {
 				case <-time.After(backoff):
-					// TODO(stevvooe): This branch holds up the next try. Before, we
+					// TODO: This branch holds up the next try. Before, we
 					// would simply break to the "retry" label and then possibly wait
 					// again. However, this requires all retry strategies to have a
 					// large probability of probing the sync for success, rather than

--- a/middleware/retry/retry_test.go
+++ b/middleware/retry/retry_test.go
@@ -1,0 +1,177 @@
+package retry_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/botchris/go-pubsub"
+	"github.com/botchris/go-pubsub/middleware/retry"
+	"github.com/botchris/go-pubsub/provider/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishInterceptor(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	t.Run("GIVEN a broker that works once every 5 publishes and with an exponential backoff recovery middleware", func(t *testing.T) {
+		mock := &intermittentFailBroker{worksEvery: 5}
+		broker := pubsub.Broker(mock)
+
+		interceptor := pubsub.WithPublishInterceptor(
+			retry.PublishInterceptor(
+				retry.NewExponentialBackoff(retry.ExponentialBackoffConfig{
+					Base:   100 * time.Millisecond,
+					Factor: 100 * time.Millisecond,
+					Max:    5 * time.Second,
+				}),
+			),
+		)
+		broker = pubsub.NewMiddlewareBroker(broker, interceptor)
+
+		t.Run("WHEN underlying publishing fails", func(t *testing.T) {
+			err := broker.Publish(ctx, "topic", "message")
+
+			t.Run("THEN publish eventually succeeds", func(t *testing.T) {
+				require.NoError(t, err)
+
+				mock.mu.RLock()
+				calls := mock.calls
+				mock.mu.RUnlock()
+
+				require.GreaterOrEqual(t, calls, 5)
+			})
+		})
+	})
+
+	t.Run("GIVEN a broker that works once every 5 publishes and with an breaker recovery middleware", func(t *testing.T) {
+		mock := &intermittentFailBroker{worksEvery: 5}
+		broker := pubsub.Broker(mock)
+
+		interceptor := pubsub.WithPublishInterceptor(
+			retry.PublishInterceptor(
+				retry.NewBreakerStrategy(5, time.Second),
+			),
+		)
+		broker = pubsub.NewMiddlewareBroker(broker, interceptor)
+
+		t.Run("WHEN underlying publishing fails 5 times in a row", func(t *testing.T) {
+			err := broker.Publish(ctx, "topic", "message")
+
+			t.Run("THEN publish eventually succeeds after waiting 1 second", func(t *testing.T) {
+				require.NoError(t, err)
+
+				mock.mu.RLock()
+				calls := mock.calls
+				mock.mu.RUnlock()
+
+				require.GreaterOrEqual(t, calls, 5)
+			})
+		})
+	})
+}
+
+func TestSubscriberInterceptor(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	t.Run("GIVEN memory broker with an exponential backoff delivery and a subscriber that works once every 5 calls", func(t *testing.T) {
+		calls := 0
+		worksEvery := 5
+		handler := func(_ context.Context, m string) error {
+			calls++
+
+			if calls%worksEvery == 0 {
+				return nil
+			}
+
+			return fmt.Errorf("fails")
+		}
+
+		broker := memory.NewBroker(memory.NopSubscriberErrorHandler)
+		interceptor := pubsub.WithSubscriberInterceptor(
+			retry.SubscriberInterceptor(
+				retry.NewExponentialBackoff(retry.ExponentialBackoffConfig{
+					Base:   100 * time.Millisecond,
+					Factor: 100 * time.Millisecond,
+					Max:    5 * time.Second,
+				}),
+			),
+		)
+
+		broker = pubsub.NewMiddlewareBroker(broker, interceptor)
+		topic := pubsub.Topic("test")
+		sub := pubsub.NewSubscriber(handler)
+
+		require.NoError(t, broker.Subscribe(ctx, topic, sub))
+
+		t.Run("WHEN publishing a message to such subscriber", func(t *testing.T) {
+			err := broker.Publish(ctx, topic, "message")
+
+			t.Run("THEN subscriber eventually receives the message after 5 attempts", func(t *testing.T) {
+				require.NoError(t, err)
+				require.GreaterOrEqual(t, calls, 5)
+			})
+		})
+	})
+
+	t.Run("GIVEN memory broker with a breaker delivery and a subscriber that works once every 5 calls", func(t *testing.T) {
+		calls := 0
+		worksEvery := 5
+		handler := func(_ context.Context, m string) error {
+			calls++
+
+			if calls%worksEvery == 0 {
+				return nil
+			}
+
+			return fmt.Errorf("fails")
+		}
+
+		broker := memory.NewBroker(memory.NopSubscriberErrorHandler)
+		interceptor := pubsub.WithSubscriberInterceptor(
+			retry.SubscriberInterceptor(
+				retry.NewBreakerStrategy(4, time.Second),
+			),
+		)
+
+		broker = pubsub.NewMiddlewareBroker(broker, interceptor)
+		topic := pubsub.Topic("test")
+		sub := pubsub.NewSubscriber(handler)
+
+		require.NoError(t, broker.Subscribe(ctx, topic, sub))
+
+		t.Run("WHEN publishing a message to such subscriber", func(t *testing.T) {
+			err := broker.Publish(ctx, topic, "message")
+
+			t.Run("THEN subscriber eventually receives the message after 5 attempts and a pause of 1s", func(t *testing.T) {
+				require.NoError(t, err)
+				require.GreaterOrEqual(t, calls, 5)
+			})
+		})
+	})
+}
+
+type intermittentFailBroker struct {
+	pubsub.Broker
+	calls      int
+	worksEvery int
+	mu         sync.RWMutex
+}
+
+func (p *intermittentFailBroker) Publish(_ context.Context, _ pubsub.Topic, _ interface{}) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.calls++
+
+	if modulo := p.calls % p.worksEvery; modulo == 0 {
+		return nil
+	}
+
+	return errors.New("publish failed")
+}

--- a/middleware/retry/strategy.go
+++ b/middleware/retry/strategy.go
@@ -1,0 +1,165 @@
+package retry
+
+import (
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/botchris/go-pubsub"
+)
+
+// Strategy defines a strategy for retrying publish or delivery operations.
+//
+// All methods should be goroutine safe.
+type Strategy interface {
+	// Proceed is called before every message is published or delivered to subscriber. If proceed returns a
+	// positive, non-zero integer, the retryer will back off by the provided duration.
+	//
+	// A message and a topic are provided, they may be ignored.
+	Proceed(topic pubsub.Topic, msg interface{}) time.Duration
+
+	// Failure reports a failure to the strategy. If this method returns true,
+	// the message should be dropped.
+	Failure(topic pubsub.Topic, msg interface{}, err error) bool
+
+	// Success should be called when a message is successfully sent.
+	Success(topic pubsub.Topic, msg interface{})
+}
+
+// Breaker implements a circuit breaker retry strategy.
+//
+// The current implementation never drops messages.
+type breakerStrategy struct {
+	threshold int
+	recent    int
+	last      time.Time
+	backoff   time.Duration // time after which we retry after failure.
+	mu        sync.Mutex
+}
+
+// NewBreakerStrategy returns a breaker that will backoff after the threshold has been
+// tripped. A Breaker is thread safe and may be shared by many goroutines.
+func NewBreakerStrategy(threshold int, backoff time.Duration) Strategy {
+	return &breakerStrategy{
+		threshold: threshold,
+		backoff:   backoff,
+	}
+}
+
+// Proceed checks the failures against the threshold.
+func (b *breakerStrategy) Proceed(topic pubsub.Topic, msg interface{}) time.Duration {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.recent < b.threshold {
+		return 0
+	}
+
+	return time.Until(b.last.Add(b.backoff))
+}
+
+// Success resets the breaker.
+func (b *breakerStrategy) Success(topic pubsub.Topic, msg interface{}) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.recent = 0
+	b.last = time.Time{}
+}
+
+// Failure records the failure and latest failure time.
+func (b *breakerStrategy) Failure(topic pubsub.Topic, msg interface{}, err error) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.recent++
+	b.last = time.Now().UTC()
+
+	return false // never drop messages.
+}
+
+// ExponentialBackoffConfig configures backoff parameters.
+//
+// Note that these parameters operate on the upper bound for choosing a random
+// value. For example, at Base=1s, a random value in [0,1s) will be chosen for
+// the backoff value.
+type ExponentialBackoffConfig struct {
+	// Base is the minimum bound for backing off after failure.
+	Base time.Duration
+
+	// Factor sets the amount of time by which the backoff grows with each
+	// failure.
+	Factor time.Duration
+
+	// Max is the absolute maximum bound for a single backoff.
+	Max time.Duration
+}
+
+// DefaultExponentialBackoffConfig provides a default configuration for
+// exponential backoff.
+var DefaultExponentialBackoffConfig = ExponentialBackoffConfig{
+	Base:   time.Second,
+	Factor: time.Second,
+	Max:    20 * time.Second,
+}
+
+// NewExponentialBackoff returns an exponential backoff strategy with the
+// desired config. If config is nil, the default is returned.
+func NewExponentialBackoff(config ExponentialBackoffConfig) Strategy {
+	return &exponentialBackoffStrategy{
+		config: config,
+	}
+}
+
+// exponentialBackoffStrategy implements random backoff with exponentially increasing
+// bounds as the number consecutive failures increase.
+type exponentialBackoffStrategy struct {
+	failures uint64 // consecutive failure counter (needs to be 64-bit aligned)
+	config   ExponentialBackoffConfig
+}
+
+// Proceed returns the next randomly bound exponential backoff time.
+func (b *exponentialBackoffStrategy) Proceed(topic pubsub.Topic, msg interface{}) time.Duration {
+	return b.backoff(atomic.LoadUint64(&b.failures))
+}
+
+// Success resets the failures counter.
+func (b *exponentialBackoffStrategy) Success(topic pubsub.Topic, msg interface{}) {
+	atomic.StoreUint64(&b.failures, 0)
+}
+
+// Failure increments the failure counter.
+func (b *exponentialBackoffStrategy) Failure(topic pubsub.Topic, msg interface{}, err error) bool {
+	atomic.AddUint64(&b.failures, 1)
+
+	return false
+}
+
+// backoff calculates the amount of time to wait based on the number of
+// consecutive failures.
+func (b *exponentialBackoffStrategy) backoff(failures uint64) time.Duration {
+	if failures <= 0 {
+		// proceed normally when there are no failures.
+		return 0
+	}
+
+	factor := b.config.Factor
+	if factor <= 0 {
+		factor = DefaultExponentialBackoffConfig.Factor
+	}
+
+	backoff := b.config.Base + factor*time.Duration(1<<(failures-1))
+
+	max := b.config.Max
+	if max <= 0 {
+		max = DefaultExponentialBackoffConfig.Max
+	}
+
+	if backoff > max || backoff < 0 {
+		backoff = max
+	}
+
+	// Choose a uniformly distributed value from [0, backoff).
+	return time.Duration(rand.Int63n(int64(backoff)))
+}

--- a/middleware/retry/strategy.go
+++ b/middleware/retry/strategy.go
@@ -1,3 +1,5 @@
+// Package retry provides retry strategies for retry middleware.
+// Credits: https://github.com/docker/go-events
 package retry
 
 import (

--- a/middleware_options.go
+++ b/middleware_options.go
@@ -52,10 +52,10 @@ func WithChainPublishInterceptors(interceptors ...PublishInterceptor) Option {
 	})
 }
 
-// WithSubscribeInterceptor returns an Option that sets the SubscriberInterceptor for the broker.
+// WithSubscriberInterceptor returns an Option that sets the SubscriberInterceptor for the broker.
 // Only one interceptor can be installed. The construction of multiple interceptors (e.g., chaining)
 // can be implemented at the caller.
-func WithSubscribeInterceptor(i SubscriberInterceptor) Option {
+func WithSubscriberInterceptor(i SubscriberInterceptor) Option {
 	return newFuncOption(func(o *options) {
 		if o.subscribeInterceptor != nil {
 			panic("the middleware subscribe interceptor was already set and may not be reset.")
@@ -65,10 +65,10 @@ func WithSubscribeInterceptor(i SubscriberInterceptor) Option {
 	})
 }
 
-// WithChainSubscribeInterceptors returns an Option that specifies the chained interceptor for subscribing.
+// WithChainSubscriberInterceptors returns an Option that specifies the chained interceptor for subscribing.
 // The first interceptor will be the outermost, while the last interceptor will be the innermost wrapper around the
 // real call. All subscribe interceptors added by this method will be chained.
-func WithChainSubscribeInterceptors(interceptors ...SubscriberInterceptor) Option {
+func WithChainSubscriberInterceptors(interceptors ...SubscriberInterceptor) Option {
 	return newFuncOption(func(o *options) {
 		o.chainSubscribeInterceptors = append(o.chainSubscribeInterceptors, interceptors...)
 	})

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -95,7 +95,7 @@ func Test_Subscribe(t *testing.T) {
 		broker := nop.NewBroker()
 		spy := newSubscribeInterceptorSpy()
 		tid := pubsub.Topic("yolo")
-		instance := pubsub.NewMiddlewareBroker(broker, pubsub.WithSubscribeInterceptor(spy.fn))
+		instance := pubsub.NewMiddlewareBroker(broker, pubsub.WithSubscriberInterceptor(spy.fn))
 		subscriber := pubsub.NewSubscriber(func(ctx context.Context, m proto.Message) error {
 			return nil
 		})
@@ -128,7 +128,7 @@ func Test_Subscribe(t *testing.T) {
 		}
 
 		tid := pubsub.Topic("yolo")
-		instance := pubsub.NewMiddlewareBroker(broker, pubsub.WithChainSubscribeInterceptors(wrapper1, wrapper2))
+		instance := pubsub.NewMiddlewareBroker(broker, pubsub.WithChainSubscriberInterceptors(wrapper1, wrapper2))
 		srx := &lockedCounter{}
 		subscriber := pubsub.NewSubscriber(func(ctx context.Context, m proto.Message) error {
 			srx.inc()


### PR DESCRIPTION
- provides retry capabilities when publishing or when delivering messages to subscribers
- minor rename "SubscribeInterceptor" is now "SubscriberInterceptor"