### PR TITLE
Subscriber interface

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -19,14 +19,14 @@ type Broker interface {
 
 	// Subscribe attaches the given Subscriber to the given topic.
 	// This method should noop in case of duplicated subscriptions.
-	Subscribe(ctx context.Context, topic Topic, subscriber *Subscriber) error
+	Subscribe(ctx context.Context, topic Topic, subscriber Subscriber) error
 
 	// Unsubscribe removes the given Subscriber from the specified topic.
 	// This method should noop if the Subscriber is not attached to the topic.
-	Unsubscribe(ctx context.Context, topic Topic, subscriber *Subscriber) error
+	Unsubscribe(ctx context.Context, topic Topic, subscriber Subscriber) error
 
 	// Subscriptions retrieves a list of subscribers currently attached to this broker.
-	Subscriptions(ctx context.Context) (map[Topic][]*Subscriber, error)
+	Subscriptions(ctx context.Context) (map[Topic][]Subscriber, error)
 
 	// Shutdown shutdowns all subscribers gracefully.
 	Shutdown(ctx context.Context) error

--- a/example/simple/example_test.go
+++ b/example/simple/example_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/botchris/go-pubsub"
 	"github.com/botchris/go-pubsub/middleware/printer"
-	"github.com/botchris/go-pubsub/middleware/recover"
+	"github.com/botchris/go-pubsub/middleware/recovery"
 	"github.com/botchris/go-pubsub/provider/memory"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -31,7 +31,7 @@ func Test_EndToEnd(t *testing.T) {
 		broker := memory.NewBroker(memory.NopSubscriberErrorHandler)
 		writer := bytes.NewBuffer([]byte{})
 		broker = printer.NewPrinterMiddleware(broker, writer)
-		broker = recover.NewRecoveryMiddleware(broker, func(ctx context.Context, p interface{}) error {
+		broker = recovery.NewRecoveryMiddleware(broker, func(ctx context.Context, p interface{}) error {
 			panics.inc()
 
 			return errors.New("panic recovery")

--- a/example/simple/example_test.go
+++ b/example/simple/example_test.go
@@ -3,12 +3,14 @@ package main_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/botchris/go-pubsub"
 	"github.com/botchris/go-pubsub/middleware/printer"
+	"github.com/botchris/go-pubsub/middleware/recover"
 	"github.com/botchris/go-pubsub/provider/memory"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -16,35 +18,62 @@ import (
 )
 
 func Test_EndToEnd(t *testing.T) {
-	t.Run("with interceptors", func(t *testing.T) {
+	t.Run("GIVEN a memory broker with a recovery and printer middlewares and two subscribers", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
+		t1 := pubsub.Topic("topic-1")
+		t2 := pubsub.Topic("topic-2")
+
+		rx := &lockedCounter{}
+		panics := &lockedCounter{}
+
 		broker := memory.NewBroker(memory.NopSubscriberErrorHandler)
-		topicID := pubsub.Topic("yolo")
 		writer := bytes.NewBuffer([]byte{})
 		broker = printer.NewPrinterMiddleware(broker, writer)
-		rx := &lockedCounter{}
-		s := pubsub.NewSubscriber(func(ctx context.Context, t pubsub.Topic, m proto.Message) error {
+		broker = recover.NewRecoveryMiddleware(broker, func(ctx context.Context, p interface{}) error {
+			panics.inc()
+
+			return errors.New("panic recovery")
+		})
+
+		s1 := pubsub.NewSubscriber(func(ctx context.Context, t pubsub.Topic, m proto.Message) error {
 			rx.inc()
 
 			return nil
 		})
 
+		s2 := pubsub.NewSubscriber(func(ctx context.Context, t pubsub.Topic, m proto.Message) error {
+			panic("boom")
+		})
+
 		require.NotNil(t, broker)
-		require.NotNil(t, s)
+		require.NotNil(t, s1)
+		require.NotNil(t, s2)
 
-		require.NoError(t, broker.Subscribe(ctx, topicID, s))
-		require.NoError(t, broker.Publish(ctx, topicID, &emptypb.Empty{}))
-		require.Equal(t, 1, rx.read())
+		require.NoError(t, broker.Subscribe(ctx, t1, s1))
+		require.NoError(t, broker.Subscribe(ctx, t2, s2))
 
-		logs := writer.String()
-		require.NotEmpty(t, logs)
-		require.Contains(t, logs, "publishing")
-		require.Contains(t, logs, "received")
+		t.Run("WHEN publishing a message to s1 THEN printer logs messages", func(t *testing.T) {
+			require.NoError(t, broker.Publish(ctx, t1, &emptypb.Empty{}))
+			require.Equal(t, 1, rx.read())
+
+			logs := writer.String()
+			require.NotEmpty(t, logs)
+			require.Contains(t, logs, "publishing")
+			require.Contains(t, logs, "received")
+		})
+
+		t.Run("WHEN publishing a message to s2 THEN panic is recovered", func(t *testing.T) {
+			require.NotPanics(t, func() {
+				require.NoError(t, broker.Publish(ctx, t2, &emptypb.Empty{}))
+			})
+
+			require.EqualValues(t, panics.read(), 1)
+		})
 	})
 
-	t.Run("without interceptors", func(t *testing.T) {
+	t.Run("without middlewares", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 

--- a/middleware/codec/codec_test.go
+++ b/middleware/codec/codec_test.go
@@ -69,7 +69,7 @@ func TestJson(t *testing.T) {
 		t.Run("WHEN publishing a custom pointer message", func(t *testing.T) {
 			require.NoError(t, broker.Publish(ctx, "test", toSend))
 
-			t.Run("THEN subscribers receives the message and decoder function is invoked only once", func(t *testing.T) {
+			t.Run("THEN subscribers receives the message and decoder is invoked only once", func(t *testing.T) {
 				require.NotEmpty(t, rcv1)
 				require.NotEmpty(t, rcv2)
 				require.EqualValues(t, jcodec.decoderCalls, 1)

--- a/middleware/codec/subscriber.go
+++ b/middleware/codec/subscriber.go
@@ -1,0 +1,65 @@
+package codec
+
+import (
+	"context"
+	"crypto/sha1"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/botchris/go-pubsub"
+	lru "github.com/hashicorp/golang-lru"
+)
+
+type subscriber struct {
+	pubsub.Subscriber
+	codec Codec
+	cache *lru.Cache
+}
+
+func (s *subscriber) Deliver(ctx context.Context, topic pubsub.Topic, m interface{}) error {
+	bytes, ok := m.([]byte)
+	if !ok {
+		return errors.New("message is not a []byte")
+	}
+
+	srf := s.Subscriber.Reflect()
+
+	h := sha1.New()
+	key := append(bytes, []byte(srf.MessageType.String())...)
+	hash := fmt.Sprintf("%x", h.Sum(key))
+
+	if found, hit := s.cache.Get(hash); hit {
+		return s.Subscriber.Deliver(ctx, topic, found)
+	}
+
+	msg, err := s.decodeFor(bytes, srf.MessageType, srf.MessageKind)
+	if err != nil {
+		return nil
+	}
+
+	s.cache.Add(hash, msg)
+
+	return s.Subscriber.Deliver(ctx, topic, msg)
+}
+
+// decodeFor attempts to dynamically decode a raw message for provided
+// subscriber using the given decoder function.
+func (s *subscriber) decodeFor(raw []byte, mType reflect.Type, mKind reflect.Kind) (interface{}, error) {
+	base := mType
+
+	if mKind == reflect.Ptr {
+		base = base.Elem()
+	}
+
+	msg := reflect.New(base).Interface()
+	if err := s.codec.Decode(raw, msg); err != nil {
+		return nil, err
+	}
+
+	if mKind == reflect.Ptr {
+		return msg, nil
+	}
+
+	return reflect.ValueOf(msg).Elem().Interface(), nil
+}

--- a/middleware/codec/subscriber.go
+++ b/middleware/codec/subscriber.go
@@ -3,7 +3,6 @@ package codec
 import (
 	"context"
 	"crypto/sha1"
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -20,7 +19,7 @@ type subscriber struct {
 func (s *subscriber) Deliver(ctx context.Context, topic pubsub.Topic, m interface{}) error {
 	bytes, ok := m.([]byte)
 	if !ok {
-		return errors.New("message is not a []byte")
+		return fmt.Errorf("delivery failure: expecting message to be of type []byte, but got `%T`", m)
 	}
 
 	srf := s.Subscriber.Reflect()

--- a/middleware/printer/printer.go
+++ b/middleware/printer/printer.go
@@ -39,7 +39,7 @@ func (mw middleware) Publish(ctx context.Context, topic pubsub.Topic, msg interf
 	return mw.Broker.Publish(ctx, topic, msg)
 }
 
-func (mw middleware) Subscribe(ctx context.Context, topic pubsub.Topic, subscriber *pubsub.Subscriber) error {
+func (mw middleware) Subscribe(ctx context.Context, topic pubsub.Topic, subscriber pubsub.Subscriber) error {
 	rs := reflect.ValueOf(subscriber).Elem()
 	rf := rs.FieldByName("handlerFunc")
 	rf = reflect.NewAt(rf.Type(), unsafe.Pointer(rf.UnsafeAddr())).Elem()

--- a/middleware/printer/printer.go
+++ b/middleware/printer/printer.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"reflect"
-	"unsafe"
 
 	"github.com/botchris/go-pubsub"
 )
@@ -39,38 +37,10 @@ func (mw middleware) Publish(ctx context.Context, topic pubsub.Topic, msg interf
 	return mw.Broker.Publish(ctx, topic, msg)
 }
 
-func (mw middleware) Subscribe(ctx context.Context, topic pubsub.Topic, subscriber pubsub.Subscriber) error {
-	rs := reflect.ValueOf(subscriber).Elem()
-	rf := rs.FieldByName("handlerFunc")
-	rf = reflect.NewAt(rf.Type(), unsafe.Pointer(rf.UnsafeAddr())).Elem()
-	originalCallable := rf.Interface().(reflect.Value)
-
-	handler := func(ctx context.Context, t pubsub.Topic, m interface{}) error {
-		j, err := json.Marshal(m)
-		if err != nil {
-			return err
-		}
-
-		log := fmt.Sprintf("[middleware] received @ %s : %s\n", topic, string(j))
-		if _, err := mw.writer.Write([]byte(log)); err != nil {
-			return err
-		}
-
-		args := []reflect.Value{
-			reflect.ValueOf(ctx),
-			reflect.ValueOf(t),
-			reflect.ValueOf(m),
-		}
-
-		if out := originalCallable.Call(args); out[0].Interface() != nil {
-			return out[0].Interface().(error)
-		}
-
-		return nil
+func (mw middleware) Subscribe(ctx context.Context, topic pubsub.Topic, sub pubsub.Subscriber) error {
+	s := &subscriber{
+		Subscriber: sub,
+		writer:     mw.writer,
 	}
-
-	newCallable := reflect.ValueOf(handler)
-	rf.Set(reflect.ValueOf(newCallable))
-
-	return mw.Broker.Subscribe(ctx, topic, subscriber)
+	return mw.Broker.Subscribe(ctx, topic, s)
 }

--- a/middleware/printer/printer_test.go
+++ b/middleware/printer/printer_test.go
@@ -1,0 +1,69 @@
+package printer_test
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/botchris/go-pubsub"
+	"github.com/botchris/go-pubsub/middleware/printer"
+	"github.com/botchris/go-pubsub/provider/memory"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestNewPrinterMiddleware(t *testing.T) {
+	t.Run("GIVEN a memory broker with a recovery middleware and two subscribers", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		t1 := pubsub.Topic("topic-1")
+		rx := &lockedCounter{}
+
+		broker := memory.NewBroker(memory.NopSubscriberErrorHandler)
+		writer := bytes.NewBuffer([]byte{})
+		broker = printer.NewPrinterMiddleware(broker, writer)
+
+		s1 := pubsub.NewSubscriber(func(ctx context.Context, t pubsub.Topic, m interface{}) error {
+			rx.inc()
+
+			return nil
+		})
+
+		require.NotNil(t, broker)
+		require.NotNil(t, s1)
+
+		require.NoError(t, broker.Subscribe(ctx, t1, s1))
+
+		t.Run("WHEN publishing a message to s1 THEN printer logs messages", func(t *testing.T) {
+			require.NoError(t, broker.Publish(ctx, t1, &emptypb.Empty{}))
+			require.Equal(t, 1, rx.read())
+
+			logs := writer.String()
+			require.NotEmpty(t, logs)
+			require.Contains(t, logs, "publishing")
+			require.Contains(t, logs, "received")
+		})
+	})
+}
+
+type lockedCounter struct {
+	sync.RWMutex
+	counter int
+}
+
+func (c *lockedCounter) inc() {
+	c.Lock()
+	defer c.Unlock()
+
+	c.counter++
+}
+
+func (c *lockedCounter) read() int {
+	c.Lock()
+	defer c.Unlock()
+
+	return c.counter
+}

--- a/middleware/printer/subscriber.go
+++ b/middleware/printer/subscriber.go
@@ -1,0 +1,31 @@
+package printer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/botchris/go-pubsub"
+)
+
+type subscriber struct {
+	pubsub.Subscriber
+	writer io.Writer
+}
+
+func (s *subscriber) Deliver(ctx context.Context, topic pubsub.Topic, m interface{}) (err error) {
+	j, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	log := fmt.Sprintf("[middleware] received @ %s : %s\n", topic, string(j))
+	if _, err := s.writer.Write([]byte(log)); err != nil {
+		return err
+	}
+
+	err = s.Subscriber.Deliver(ctx, topic, m)
+
+	return
+}

--- a/middleware/recover/subscriber.go
+++ b/middleware/recover/subscriber.go
@@ -1,0 +1,24 @@
+package recover
+
+import (
+	"context"
+
+	"github.com/botchris/go-pubsub"
+)
+
+type subscriber struct {
+	pubsub.Subscriber
+	handler RecoveryHandlerFunc
+}
+
+func (s *subscriber) Deliver(ctx context.Context, topic pubsub.Topic, m interface{}) (err error) {
+	defer func(ctx context.Context) {
+		if r := recover(); r != nil {
+			err = recoverFrom(ctx, r, "pubsub: subscriber panic\n", s.handler)
+		}
+	}(ctx)
+
+	err = s.Subscriber.Deliver(ctx, topic, m)
+
+	return
+}

--- a/middleware/recovery/recover_test.go
+++ b/middleware/recovery/recover_test.go
@@ -1,4 +1,4 @@
-package recover_test
+package recovery_test
 
 import (
 	"context"
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/botchris/go-pubsub"
-	"github.com/botchris/go-pubsub/middleware/recover"
+	"github.com/botchris/go-pubsub/middleware/recovery"
 	"github.com/botchris/go-pubsub/provider/memory"
 	"github.com/stretchr/testify/require"
 )
@@ -20,11 +20,11 @@ func TestPublishInterceptor(t *testing.T) {
 		broker := pubsub.Broker(&panicBroker{})
 
 		recoveryErr := errors.New("recovery function")
-		recovery := func(ctx context.Context, p interface{}) error {
+		rec := func(ctx context.Context, p interface{}) error {
 			return recoveryErr
 		}
 
-		broker = recover.NewRecoveryMiddleware(broker, recovery)
+		broker = recovery.NewRecoveryMiddleware(broker, rec)
 
 		t.Run("WHEN publish panics", func(t *testing.T) {
 			var err error
@@ -49,13 +49,13 @@ func TestSubscribeInterceptor(t *testing.T) {
 		broker := memory.NewBroker(memory.NopSubscriberErrorHandler)
 
 		recoveryCalls := 0
-		recovery := func(ctx context.Context, p interface{}) error {
+		rec := func(ctx context.Context, p interface{}) error {
 			recoveryCalls++
 
 			return errors.New("recovery function")
 		}
 
-		broker = recover.NewRecoveryMiddleware(broker, recovery)
+		broker = recovery.NewRecoveryMiddleware(broker, rec)
 
 		subCalls := 0
 		sub := pubsub.NewSubscriber(func(ctx context.Context, t pubsub.Topic, p string) error {

--- a/middleware/recovery/subscriber.go
+++ b/middleware/recovery/subscriber.go
@@ -1,4 +1,4 @@
-package recover
+package recovery
 
 import (
 	"context"
@@ -8,13 +8,13 @@ import (
 
 type subscriber struct {
 	pubsub.Subscriber
-	handler RecoveryHandlerFunc
+	handler HandlerFunc
 }
 
 func (s *subscriber) Deliver(ctx context.Context, topic pubsub.Topic, m interface{}) (err error) {
 	defer func(ctx context.Context) {
-		if r := recover(); r != nil {
-			err = recoverFrom(ctx, r, "pubsub: subscriber panic\n", s.handler)
+		if p := recover(); p != nil {
+			err = s.handler(ctx, p)
 		}
 	}(ctx)
 

--- a/middleware/retry/retry.go
+++ b/middleware/retry/retry.go
@@ -3,9 +3,7 @@ package retry
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
-	"unsafe"
 
 	"github.com/botchris/go-pubsub"
 )
@@ -64,62 +62,11 @@ retry:
 	return nil
 }
 
-func (mw middleware) Subscribe(ctx context.Context, topic pubsub.Topic, subscriber *pubsub.Subscriber) error {
-	rs := reflect.ValueOf(subscriber).Elem()
-	rf := rs.FieldByName("handlerFunc")
-	rf = reflect.NewAt(rf.Type(), unsafe.Pointer(rf.UnsafeAddr())).Elem()
-	originalCallable := rf.Interface().(reflect.Value)
-
-	handler := func(ctx context.Context, t pubsub.Topic, m interface{}) error {
-		done := ctx.Done()
-		args := []reflect.Value{
-			reflect.ValueOf(ctx),
-			reflect.ValueOf(t),
-			reflect.ValueOf(m),
-		}
-
-	retry:
-		select {
-		case <-done:
-			return fmt.Errorf("context cancelled")
-		default:
-		}
-
-		if backoff := mw.subscriberStrategy.Proceed(topic, m); backoff > 0 {
-			select {
-			case <-time.After(backoff):
-				// TODO: This branch holds up the next try. Before, we
-				// would simply break to the "retry" label and then possibly wait
-				// again. However, this requires all retry strategies to have a
-				// large probability of probing the sync for success, rather than
-				// just backing off and sending the request.
-			case <-done:
-				return fmt.Errorf("context cancelled")
-			}
-		}
-
-		var nErr error
-		if out := originalCallable.Call(args); out[0].Interface() != nil {
-			nErr = out[0].Interface().(error)
-		}
-
-		if nErr != nil {
-			if mw.subscriberStrategy.Failure(topic, m, nErr) {
-				fmt.Printf("retrying delivery error, cause: message was dropped, retries exhausted {topic=%s, error=%s}\n", topic, nErr)
-
-				return nil
-			}
-
-			goto retry
-		}
-
-		mw.subscriberStrategy.Success(topic, m)
-
-		return nil
+func (mw middleware) Subscribe(ctx context.Context, topic pubsub.Topic, sub pubsub.Subscriber) error {
+	s := &subscriber{
+		Subscriber: sub,
+		strategy:   mw.subscriberStrategy,
 	}
 
-	newCallable := reflect.ValueOf(handler)
-	rf.Set(reflect.ValueOf(newCallable))
-
-	return mw.Broker.Subscribe(ctx, topic, subscriber)
+	return mw.Broker.Subscribe(ctx, topic, s)
 }

--- a/middleware/retry/subscriber.go
+++ b/middleware/retry/subscriber.go
@@ -1,0 +1,52 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/botchris/go-pubsub"
+)
+
+type subscriber struct {
+	pubsub.Subscriber
+	strategy Strategy
+}
+
+func (s *subscriber) Deliver(ctx context.Context, topic pubsub.Topic, m interface{}) error {
+	done := ctx.Done()
+
+retry:
+	select {
+	case <-done:
+		return fmt.Errorf("context cancelled")
+	default:
+	}
+
+	if backoff := s.strategy.Proceed(topic, m); backoff > 0 {
+		select {
+		case <-time.After(backoff):
+			// TODO: This branch holds up the next try. Before, we
+			// would simply break to the "retry" label and then possibly wait
+			// again. However, this requires all retry strategies to have a
+			// large probability of probing the sync for success, rather than
+			// just backing off and sending the request.
+		case <-done:
+			return fmt.Errorf("context cancelled")
+		}
+	}
+
+	if err := s.Subscriber.Deliver(ctx, topic, m); err != nil {
+		if s.strategy.Failure(topic, m, err) {
+			fmt.Printf("retrying delivery error, cause: message was dropped, retries exhausted {topic=%s, error=%s}\n", topic, err)
+
+			return nil
+		}
+
+		goto retry
+	}
+
+	s.strategy.Success(topic, m)
+
+	return nil
+}

--- a/provider/kmq/broker.go
+++ b/provider/kmq/broker.go
@@ -33,6 +33,8 @@ type subscription struct {
 //
 // IMPORTANT: this broker must be used in conjunction with a Codec middleware in
 // order to ensure that the messages are properly encoded and decoded.
+// Otherwise, only binary messages will be accepted when publishing or
+// delivering messages.
 func NewBroker(ctx context.Context, option ...Option) (pubsub.Broker, error) {
 	opts := &options{
 		serverPort:       50000,

--- a/provider/kmq/broker_test.go
+++ b/provider/kmq/broker_test.go
@@ -305,22 +305,3 @@ func (c *consumer) received() queue {
 
 	return out
 }
-
-type lockedCounter struct {
-	mu      sync.RWMutex
-	counter int
-}
-
-func (c *lockedCounter) inc() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.counter++
-}
-
-func (c *lockedCounter) read() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return c.counter
-}

--- a/provider/kmq/broker_test.go
+++ b/provider/kmq/broker_test.go
@@ -12,6 +12,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func BenchmarkPublish(b *testing.B) {
+	ctx := context.Background()
+
+	clientID := "test-client"
+	topic := pubsub.Topic("topic")
+	message := "hello"
+
+	broker, err := prepareBroker(ctx, clientID, "")
+	require.NoError(b, err)
+
+	defer broker.Shutdown(ctx)
+
+	s1 := pubsub.NewSubscriber(func(ctx context.Context, t pubsub.Topic, m string) error {
+		return nil
+	})
+
+	require.NoError(b, broker.Subscribe(ctx, topic, s1))
+
+	b.StartTimer()
+	for i := 0; i <= b.N; i++ {
+		_ = broker.Publish(ctx, topic, message)
+	}
+	b.StopTimer()
+}
+
 func TestSingleBroker(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/provider/kmq/broker_test.go
+++ b/provider/kmq/broker_test.go
@@ -24,7 +24,9 @@ func BenchmarkPublishJSONTenSubs(b *testing.B) {
 	broker, err := prepareJSONBroker(ctx, clientID, "")
 	require.NoError(b, err)
 
-	defer broker.Shutdown(ctx)
+	defer func() {
+		require.NoError(b, broker.Shutdown(ctx))
+	}()
 
 	for i := 0; i < 10; i++ {
 		s := pubsub.NewSubscriber(func(ctx context.Context, t pubsub.Topic, m string) error {
@@ -56,7 +58,9 @@ func BenchmarkPublishProtoTenSubs(b *testing.B) {
 	broker, err := prepareProtoBroker(ctx, clientID, "")
 	require.NoError(b, err)
 
-	defer broker.Shutdown(ctx)
+	defer func() {
+		require.NoError(b, broker.Shutdown(ctx))
+	}()
 
 	for i := 0; i < 10; i++ {
 		s := pubsub.NewSubscriber(func(ctx context.Context, t pubsub.Topic, m string) error {

--- a/provider/kmq/encoding.go
+++ b/provider/kmq/encoding.go
@@ -1,7 +1,0 @@
-package kmq
-
-// Encoder receives an object and encodes it into a byte array.
-type Encoder func(msg interface{}) ([]byte, error)
-
-// Decoder receives a byte array and decodes it into an object.
-type Decoder func(data []byte) (interface{}, error)

--- a/provider/kmq/options.go
+++ b/provider/kmq/options.go
@@ -14,8 +14,6 @@ type options struct {
 	serverPort       int
 	clientID         string
 	groupID          string
-	encoder          Encoder
-	decoder          Decoder
 	onStreamError    func(error)
 	onSubscribeError func(error)
 	deliverTimeout   time.Duration
@@ -63,26 +61,6 @@ func WithGroupID(groupID string) Option {
 	return fnOption{
 		f: func(o *options) {
 			o.groupID = groupID
-		},
-	}
-}
-
-// WithEncoder sets the encoder function to be used by broker.
-// Use this to define how messages are encoded before sending to the SNS service.
-func WithEncoder(e Encoder) Option {
-	return fnOption{
-		f: func(o *options) {
-			o.encoder = e
-		},
-	}
-}
-
-// WithDecoder sets the decoder function to be used by broker.
-// Use this to define how messages are decoded after receiving from the SQS service.
-func WithDecoder(d Decoder) Option {
-	return fnOption{
-		f: func(o *options) {
-			o.decoder = d
 		},
 	}
 }

--- a/provider/memory/broker.go
+++ b/provider/memory/broker.go
@@ -1,7 +1,8 @@
 // Package memory provides a simple in-memory Broker.
 //
-// This broker should never be used for IPC purposes (Inter-Process Communication) as it only works by moving
-// messages using local memory.
+// This broker should never be used for IPC purposes
+// (Inter-Process Communication) as it only works by moving messages using
+// local memory.
 package memory
 
 import (
@@ -11,7 +12,8 @@ import (
 	"github.com/botchris/go-pubsub"
 )
 
-// SubscriberErrorHandler used to handle subscribers errors when processing a message.
+// SubscriberErrorHandler used to handle subscribers errors when delivering a
+// message.
 type SubscriberErrorHandler func(ctx context.Context, topic pubsub.Topic, s pubsub.Subscriber, m interface{}, err error)
 
 // NopSubscriberErrorHandler an empty error handler

--- a/provider/memory/broker.go
+++ b/provider/memory/broker.go
@@ -12,10 +12,10 @@ import (
 )
 
 // SubscriberErrorHandler used to handle subscribers errors when processing a message.
-type SubscriberErrorHandler func(ctx context.Context, topic pubsub.Topic, s *pubsub.Subscriber, m interface{}, err error)
+type SubscriberErrorHandler func(ctx context.Context, topic pubsub.Topic, s pubsub.Subscriber, m interface{}, err error)
 
 // NopSubscriberErrorHandler an empty error handler
-var NopSubscriberErrorHandler = func(ctx context.Context, topic pubsub.Topic, s *pubsub.Subscriber, m interface{}, err error) {}
+var NopSubscriberErrorHandler = func(ctx context.Context, topic pubsub.Topic, s pubsub.Subscriber, m interface{}, err error) {}
 
 type broker struct {
 	topics        map[pubsub.Topic]*topic
@@ -45,7 +45,7 @@ func (b *broker) Publish(ctx context.Context, topic pubsub.Topic, m interface{})
 	return nil
 }
 
-func (b *broker) Subscribe(_ context.Context, topic pubsub.Topic, subscriber *pubsub.Subscriber) error {
+func (b *broker) Subscribe(_ context.Context, topic pubsub.Topic, subscriber pubsub.Subscriber) error {
 	b.Lock()
 	defer b.Unlock()
 
@@ -54,7 +54,7 @@ func (b *broker) Subscribe(_ context.Context, topic pubsub.Topic, subscriber *pu
 	return nil
 }
 
-func (b *broker) Unsubscribe(_ context.Context, topic pubsub.Topic, subscriber *pubsub.Subscriber) error {
+func (b *broker) Unsubscribe(_ context.Context, topic pubsub.Topic, subscriber pubsub.Subscriber) error {
 	b.Lock()
 	defer b.Unlock()
 
@@ -68,11 +68,11 @@ func (b *broker) Unsubscribe(_ context.Context, topic pubsub.Topic, subscriber *
 	return nil
 }
 
-func (b *broker) Subscriptions(_ context.Context) (map[pubsub.Topic][]*pubsub.Subscriber, error) {
+func (b *broker) Subscriptions(_ context.Context) (map[pubsub.Topic][]pubsub.Subscriber, error) {
 	b.RLock()
 	defer b.RUnlock()
 
-	out := make(map[pubsub.Topic][]*pubsub.Subscriber)
+	out := make(map[pubsub.Topic][]pubsub.Subscriber)
 
 	for tName, t := range b.topics {
 		for _, s := range t.subscribers {

--- a/provider/memory/broker_test.go
+++ b/provider/memory/broker_test.go
@@ -24,7 +24,7 @@ func BenchmarkPublish(b *testing.B) {
 
 	broker := memory.NewBroker(memory.NopSubscriberErrorHandler)
 
-	s1 := pubsub.NewSubscriber(func(ctx context.Context, m interface{}) error {
+	s1 := pubsub.NewSubscriber(func(ctx context.Context, t pubsub.Topic, m interface{}) error {
 		return nil
 	})
 

--- a/provider/memory/broker_test.go
+++ b/provider/memory/broker_test.go
@@ -291,7 +291,7 @@ func Test_Broker_Publish(t *testing.T) {
 		ctx := context.Background()
 		subError := fmt.Errorf("dummy error")
 		errors := &lockedCounter{}
-		errHandler := func(ctx context.Context, topic pubsub.Topic, s *pubsub.Subscriber, m interface{}, err error) {
+		errHandler := func(ctx context.Context, topic pubsub.Topic, s pubsub.Subscriber, m interface{}, err error) {
 			errors.Inc()
 		}
 

--- a/provider/memory/topic.go
+++ b/provider/memory/topic.go
@@ -10,12 +10,12 @@ import (
 // topic defines a in-memory topic to which subscriber may subscribe to
 type topic struct {
 	id          pubsub.Topic
-	subscribers map[string]*pubsub.Subscriber
+	subscribers map[string]pubsub.Subscriber
 	sync.RWMutex
 }
 
 type publishResult struct {
-	subscriber *pubsub.Subscriber
+	subscriber pubsub.Subscriber
 	err        error
 }
 
@@ -23,7 +23,7 @@ type publishResult struct {
 func newTopic(id pubsub.Topic) *topic {
 	return &topic{
 		id:          id,
-		subscribers: map[string]*pubsub.Subscriber{},
+		subscribers: map[string]pubsub.Subscriber{},
 	}
 }
 
@@ -59,7 +59,7 @@ func (t *topic) publish(ctx context.Context, m interface{}) []*publishResult {
 }
 
 // subscribe attaches to this topic the given subscriber, attaching multiple times the same subscriber has no effects.
-func (t *topic) subscribe(s *pubsub.Subscriber) {
+func (t *topic) subscribe(s pubsub.Subscriber) {
 	t.Lock()
 	defer t.Unlock()
 
@@ -67,7 +67,7 @@ func (t *topic) subscribe(s *pubsub.Subscriber) {
 }
 
 // unsubscribe detaches from this topic the given subscriber, will nop if subscriber is not present.
-func (t *topic) unsubscribe(s *pubsub.Subscriber) {
+func (t *topic) unsubscribe(s pubsub.Subscriber) {
 	t.Lock()
 	defer t.Unlock()
 

--- a/provider/nop/nop.go
+++ b/provider/nop/nop.go
@@ -17,16 +17,16 @@ func (b *broker) Publish(_ context.Context, _ pubsub.Topic, _ interface{}) error
 	return nil
 }
 
-func (b *broker) Subscribe(_ context.Context, _ pubsub.Topic, _ *pubsub.Subscriber) error {
+func (b *broker) Subscribe(_ context.Context, _ pubsub.Topic, _ pubsub.Subscriber) error {
 	return nil
 }
 
-func (b *broker) Unsubscribe(_ context.Context, _ pubsub.Topic, _ *pubsub.Subscriber) error {
+func (b *broker) Unsubscribe(_ context.Context, _ pubsub.Topic, _ pubsub.Subscriber) error {
 	return nil
 }
 
-func (b *broker) Subscriptions(_ context.Context) (map[pubsub.Topic][]*pubsub.Subscriber, error) {
-	return map[pubsub.Topic][]*pubsub.Subscriber{}, nil
+func (b *broker) Subscriptions(_ context.Context) (map[pubsub.Topic][]pubsub.Subscriber, error) {
+	return map[pubsub.Topic][]pubsub.Subscriber{}, nil
 }
 
 func (b *broker) Shutdown(_ context.Context) error {

--- a/provider/nop/nop.go
+++ b/provider/nop/nop.go
@@ -6,7 +6,7 @@ import (
 	"github.com/botchris/go-pubsub"
 )
 
-// NewBroker returns a new NO-OP broker instance
+// NewBroker returns a new broker instance that does nothing.
 func NewBroker() pubsub.Broker {
 	return &broker{}
 }

--- a/provider/nop/nop_test.go
+++ b/provider/nop/nop_test.go
@@ -1,12 +1,44 @@
 package nop_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/botchris/go-pubsub"
 	"github.com/botchris/go-pubsub/provider/nop"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewBroker(t *testing.T) {
-	require.NotNil(t, nop.NewBroker())
+func TestBroker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t.Run("GIVEN a nop broker", func(t *testing.T) {
+		broker := nop.NewBroker()
+		require.NotNil(t, broker)
+
+		t.Run("WHEN publishing a message THEN no error are raised", func(t *testing.T) {
+			require.NoError(t, broker.Publish(ctx, "test", "testing"))
+		})
+	})
+
+	t.Run("GIVEN a nop broker and a subscriber", func(t *testing.T) {
+		broker := nop.NewBroker()
+		require.NotNil(t, broker)
+
+		sub := pubsub.NewSubscriber(func(ctx context.Context, t pubsub.Topic, m string) error {
+			return nil
+		})
+
+		t.Run("WHEN adding a subscriber", func(t *testing.T) {
+			require.NoError(t, broker.Subscribe(ctx, "testing", sub))
+
+			t.Run("THEN broker has no subscriptions", func(t *testing.T) {
+				subs, err := broker.Subscriptions(ctx)
+				require.NoError(t, err)
+				require.Empty(t, subs)
+			})
+		})
+	})
 }

--- a/provider/sns/broker.go
+++ b/provider/sns/broker.go
@@ -42,6 +42,8 @@ type subscription struct {
 //
 // IMPORTANT: this broker must be used in conjunction with a Codec middleware in
 // order to ensure that the messages are properly encoded and decoded.
+// Otherwise, only binary messages will be accepted when publishing or
+// delivering messages.
 func NewBroker(ctx context.Context, option ...Option) (pubsub.Broker, error) {
 	opts := &options{
 		deliverTimeout:       3 * time.Second,

--- a/provider/sns/broker.go
+++ b/provider/sns/broker.go
@@ -27,7 +27,7 @@ type broker struct {
 type subscription struct {
 	arn     string
 	topic   pubsub.Topic
-	handler *pubsub.Subscriber
+	handler pubsub.Subscriber
 }
 
 // NewBroker returns a broker that uses AWS SNS service for pub/sub messaging over a SQS queue.
@@ -111,7 +111,7 @@ func (b *broker) Publish(ctx context.Context, topic pubsub.Topic, m interface{})
 	return nil
 }
 
-func (b *broker) Subscribe(ctx context.Context, topic pubsub.Topic, subscriber *pubsub.Subscriber) error {
+func (b *broker) Subscribe(ctx context.Context, topic pubsub.Topic, subscriber pubsub.Subscriber) error {
 	topicARN, err := b.topics.arnOf(topic)
 	if err != nil {
 		return err
@@ -143,7 +143,7 @@ func (b *broker) Subscribe(ctx context.Context, topic pubsub.Topic, subscriber *
 	return nil
 }
 
-func (b *broker) Unsubscribe(ctx context.Context, topic pubsub.Topic, subscriber *pubsub.Subscriber) error {
+func (b *broker) Unsubscribe(ctx context.Context, topic pubsub.Topic, subscriber pubsub.Subscriber) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -170,8 +170,8 @@ func (b *broker) Unsubscribe(ctx context.Context, topic pubsub.Topic, subscriber
 	return nil
 }
 
-func (b *broker) Subscriptions(_ context.Context) (map[pubsub.Topic][]*pubsub.Subscriber, error) {
-	out := make(map[pubsub.Topic][]*pubsub.Subscriber)
+func (b *broker) Subscriptions(_ context.Context) (map[pubsub.Topic][]pubsub.Subscriber, error) {
+	out := make(map[pubsub.Topic][]pubsub.Subscriber)
 
 	for topic, subs := range b.subs {
 		for _, sub := range subs {

--- a/provider/sns/encoding.go
+++ b/provider/sns/encoding.go
@@ -1,7 +1,0 @@
-package sns
-
-// Encoder receives an object and encodes it into a byte array.
-type Encoder func(msg interface{}) ([]byte, error)
-
-// Decoder receives a byte array and decodes it into an object.
-type Decoder func(data []byte) (interface{}, error)

--- a/provider/sns/options.go
+++ b/provider/sns/options.go
@@ -13,8 +13,6 @@ type options struct {
 	snsClient            AWSSNSAPI
 	sqsClient            AWSSQSAPI
 	sqsQueueURL          string
-	encoder              Encoder
-	decoder              Decoder
 	deliverTimeout       time.Duration
 	topicsReloadInterval time.Duration
 	maxMessages          int32
@@ -53,26 +51,6 @@ func WithSQSQueueURL(sqsQueueURL string) Option {
 	return fnOption{
 		f: func(o *options) {
 			o.sqsQueueURL = sqsQueueURL
-		},
-	}
-}
-
-// WithEncoder sets the encoder function to be used by broker.
-// Use this to define how messages are encoded before sending to the SNS service.
-func WithEncoder(e Encoder) Option {
-	return fnOption{
-		f: func(o *options) {
-			o.encoder = e
-		},
-	}
-}
-
-// WithDecoder sets the decoder function to be used by broker.
-// Use this to define how messages are decoded after receiving from the SQS service.
-func WithDecoder(d Decoder) Option {
-	return fnOption{
-		f: func(o *options) {
-			o.decoder = d
 		},
 	}
 }


### PR DESCRIPTION
- Subscriber is now an interface
- Refactoring middleware to use interface wrapping instead of heavy reflection
- Refactoring SNS and KubeMQ providers, they no longer requires a Encoder/Decoder. They must be used in conjunction with a Codec middleware instead