### PR TITLE
Interface segregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,26 @@ The `go-pubsub` package comes with a set of built-in providers:
 ### Creating your own provider
 
 This packages moves around the `Broker` interface definition, which is the 
-central piece for dealing with PubSub systems:
+central piece for dealing with PubSub systems. The `Broker` interface is a 
+composition of three independent interfaces which can be used in order to keep
+you application concerns clean and separated:
 
 ```go
-// Broker defines the interface for a pub/sub broker.
 type Broker interface {
-	// Publish the given message on the given topic.
+	Publisher
+	Subscriber
+	Shutdowner
+}
+
+type Publisher interface {
 	Publish(ctx context.Context, topic Topic, m interface{}) error
+}
 
-	// Subscribe attaches the given handler to the given topic.
-	// The same handler could be attached multiple times to the same topic.
+type Subscriber interface {
 	Subscribe(ctx context.Context, topic Topic, handler Handler, option ...SubscribeOption) (Subscription, error)
+}
 
-	// Shutdown gracefully shutdowns all subscriptions.
+type Shutdowner interface {
 	Shutdown(ctx context.Context) error
 }
 ```

--- a/broker.go
+++ b/broker.go
@@ -12,15 +12,46 @@ func (t Topic) String() string {
 	return string(t)
 }
 
-// Broker defines the interface for a pub/sub broker.
-type Broker interface {
+// Publisher is a convenience definition which extract topic-publishing behavior
+// into an independent interface.
+//
+// This is specially useful when needing to publish messages without having to
+// expose  the entire Broker implementation.
+type Publisher interface {
 	// Publish the given message on the given topic.
 	Publish(ctx context.Context, topic Topic, m interface{}) error
+}
 
+// Subscriber is a convenience definition which extract topic-subscription
+// behavior into an independent interface.
+//
+// This is specially useful when needing to subscribe to topics without having
+// to expose the entire Broker implementation.
+type Subscriber interface {
 	// Subscribe attaches the given handler to the given topic.
-	// The same handler could be attached multiple times to the same topic.
+	//
+	// The same Handler can be reused and attached multiple times to the same
+	// or distinct topics.
 	Subscribe(ctx context.Context, topic Topic, handler Handler, option ...SubscribeOption) (Subscription, error)
+}
 
+// Shutdowner provides a method that can manually trigger the shutdown of the
+// Broker by gracefully closing each subscription.
+//
+// Use this interface when you need to manually shutdown the Broker. Use with
+// care, as it will prevent the broker from publishing or receiving any
+// messages.
+type Shutdowner interface {
 	// Shutdown gracefully shutdowns all subscriptions.
+	//
+	// The provided context acts as a hard-limit cancellation for the shutdown
+	// process.
 	Shutdown(ctx context.Context) error
+}
+
+// Broker defines the interface for a pub/sub broker.
+type Broker interface {
+	Publisher
+	Subscriber
+	Shutdowner
 }

--- a/middleware/codec/codec.go
+++ b/middleware/codec/codec.go
@@ -23,11 +23,13 @@ type middleware struct {
 // messages when publishing and delivering.
 //
 // When Publishing:
-// Intercepts each message and encodes it before publishing to underlying broker.
+// Intercepts each message being published and encodes it before passing it to
+// wrapped broker.
 //
 // When Delivering:
-// Intercepts each message before it gets delivered to handlers and decodes it
-// to handler's accepted type assuming that the incoming message is a byte slice.
+// Intercepts each message before it gets delivered to subscriber handlers and
+// decodes into handler's accepted type assuming that the incoming message is a
+// byte slice (`[]byte`)
 //
 // Decoder function is invoked once for each desired type, and it takes
 // two arguments:
@@ -47,14 +49,16 @@ type middleware struct {
 // - `map[string]string`
 //
 // If decoder is unable to convert the given byte slice into the desired type
-// (string or map in the above example), and error must be returned. This will
-// prevent from delivering the message to underlying handler.
+// (string or map in the above example), an error must be returned by Codec
+// implementations. This will prevent from delivering the message to underlying
+// handler.
 //
-// NOTE: message decoding are expensive operations.
-// In the other hand, interceptors are applied each time a message is delivered
-// to handlers. This may produce unnecessary decoding operation when the same
-// message is delivered to multiple handlers/subscriptions. To address this
-// issue, this interceptor uses a small LRU cache of each seen decoded message.
+// IMPORTANT: message decoding are expensive operations.
+// In the other hand, delivery interception occurs each time a message is
+// delivered to subscriber handlers. This may produce unnecessary decoding
+// operation when the same message is delivered to multiple subscriptions. To
+// address this issue, this middleware uses a small in-memory LRU cache of each
+// seen decoded message.
 func NewCodecMiddleware(broker pubsub.Broker, codec Codec) pubsub.Broker {
 	cache, _ := lru.New(256)
 

--- a/stoppable.go
+++ b/stoppable.go
@@ -8,14 +8,15 @@ import (
 // StoppableSubscription represents a subscription that can be stopped.
 //
 // Generally used by brokers implementations that relies on background running
-// goroutines for handling subscriptions and message receptions from services
+// goroutines for handling subscriptions and message receptions from remote
+// backends, e.g. Kafka, NATS, etc.
 type StoppableSubscription interface {
 	Subscription
 
 	// Context returns the internal context of this subscription which controls
 	// its life cycle. This is usually branched from broker's internal context,
 	// and allows implementing graceful shutdown mechanisms when broker decides
-	//to stop.
+	// to stop.
 	Context() context.Context
 
 	// Stop is used to signal the subscription to stop. This is usually invoked
@@ -49,7 +50,8 @@ func (s *stoppable) Stop() {
 }
 
 // NewStoppableSubscription builds a new stoppable subscription. Given context
-// should be the broker's internal context, this allows to implement graceful shutdown.
+// should be the broker's internal context, this allows to implement graceful
+// shutdown.
 func NewStoppableSubscription(
 	ctx context.Context,
 	id string,

--- a/subscription.go
+++ b/subscription.go
@@ -15,7 +15,8 @@ type Subscription interface {
 	// Unsubscribe unsubscribes.
 	Unsubscribe() error
 
-	// Handler returns the Handler this subscription will use to handle messages.
+	// Handler returns the underlying Handler function this subscription will
+	// use when receiving messages.
 	Handler() Handler
 }
 


### PR DESCRIPTION
making Broker interface a composition of "Publisher", "Subscriber" & "Shutdowner". This allows to move the Broker implementation around into application layers without having to expose the entire definition.