### PR TITLE
Middleware fixes & refactor

### DIFF
--- a/middleware/pool/options.go
+++ b/middleware/pool/options.go
@@ -1,21 +1,29 @@
 package pool
 
-import "time"
+import (
+	"time"
+
+	"github.com/botchris/go-pubsub"
+)
 
 // Option is a configuration function that can be passed to NewPoolMiddleware.
 type Option func(*options)
+
+// PublishErrorHandler is a function that handles errors that occur during the
+// publish operation.
+type PublishErrorHandler func(t pubsub.Topic, m interface{}, err error)
 
 type options struct {
 	timeout     time.Duration
 	queueSize   int
 	nonBlocking bool
-	onError     func(m interface{}, err error)
+	onError     PublishErrorHandler
 }
 
 // WithOnError sets Publish error handler function.
-func WithOnError(onError func(m interface{}, err error)) Option {
+func WithOnError(fn PublishErrorHandler) Option {
 	return func(p *options) {
-		p.onError = onError
+		p.onError = fn
 	}
 }
 
@@ -28,6 +36,10 @@ func WithTimeout(timeout time.Duration) Option {
 }
 
 // WithQueueSize sets the max number of elements that can be queued in the pool.
+//
+// By default, messages are queued indefinitely until the pool is stopped (or the process
+// runs out of memory). You can limit the number of messages that can be queued by setting
+// a queue size option.
 func WithQueueSize(size int) Option {
 	return func(p *options) {
 		p.queueSize = size
@@ -36,6 +48,11 @@ func WithQueueSize(size int) Option {
 
 // WithNonBlocking sets the pool to be non-blocking when the queue is full.
 // This option is only effective when the queue size is set.
+//
+// By default, when using queue size option, messages publishing blocks until there is space in the queue,
+// but you can change this behavior to non-blocking by setting the WithNonBlocking option to true.
+// If the queue is full and non-blocking mode is enabled, the message is dropped and an error is returned
+// (pond.ErrQueueFull).
 func WithNonBlocking(nonBlocking bool) Option {
 	return func(p *options) {
 		p.nonBlocking = nonBlocking

--- a/middleware/retry/options.go
+++ b/middleware/retry/options.go
@@ -1,0 +1,39 @@
+package retry
+
+import "github.com/botchris/go-pubsub"
+
+type options struct {
+	publishStrategy Strategy
+	deliverStrategy Strategy
+	publishError    PublishErrorHandler
+}
+
+// PublishErrorHandler is a function that handles errors that occur during the
+// publish operation after all retries have been exhausted.
+type PublishErrorHandler func(t pubsub.Topic, m interface{}, err error)
+
+// Option is a configuration function that can be passed to NewRetryMiddleware.
+type Option func(*options)
+
+// WithPublishStrategy sets the strategy to be used when retrying a publish operation.
+func WithPublishStrategy(s Strategy) Option {
+	return func(o *options) {
+		o.publishStrategy = s
+	}
+}
+
+// WithDeliverStrategy sets the strategy to be used when retrying a deliver operation
+// to a subscriber handler function.
+func WithDeliverStrategy(s Strategy) Option {
+	return func(o *options) {
+		o.deliverStrategy = s
+	}
+}
+
+// WithPublishError sets the error handler function to be called when a publish operation
+// fails after all retries have been exhausted.
+func WithPublishError(fn PublishErrorHandler) Option {
+	return func(o *options) {
+		o.publishError = fn
+	}
+}

--- a/middleware/retry/retry.go
+++ b/middleware/retry/retry.go
@@ -10,8 +10,7 @@ import (
 
 type middleware struct {
 	pubsub.Broker
-	publishStrategy Strategy
-	deliverStrategy Strategy
+	options *options
 }
 
 // NewRetryMiddleware returns a middleware that retries messages that fail to
@@ -20,11 +19,20 @@ type middleware struct {
 // Strategies must be configured accordingly, so they can retry as long as
 // operation contexts keeps alive. For instance, when publishing a message, the
 // maximum execution time is determined by the provided context.
-func NewRetryMiddleware(broker pubsub.Broker, publish Strategy, deliver Strategy) pubsub.Broker {
+func NewRetryMiddleware(broker pubsub.Broker, o ...Option) pubsub.Broker {
+	opts := &options{
+		publishStrategy: NewExponentialBackoff(DefaultExponentialBackoffConfig),
+		deliverStrategy: NewExponentialBackoff(DefaultExponentialBackoffConfig),
+		publishError:    func(t pubsub.Topic, m interface{}, err error) {},
+	}
+
+	for _, opt := range o {
+		opt(opts)
+	}
+
 	return &middleware{
-		Broker:          broker,
-		publishStrategy: publish,
-		deliverStrategy: deliver,
+		Broker:  broker,
+		options: opts,
 	}
 }
 
@@ -38,7 +46,7 @@ retry:
 	default:
 	}
 
-	if backoff := mw.publishStrategy.Proceed(topic, m); backoff > 0 {
+	if backoff := mw.options.publishStrategy.Proceed(topic, m); backoff > 0 {
 		select {
 		case <-time.After(backoff):
 			// TODO: This branch holds up the next try. Before, we
@@ -52,7 +60,7 @@ retry:
 	}
 
 	if nErr := mw.Broker.Publish(ctx, topic, m); nErr != nil {
-		if mw.publishStrategy.Failure(topic, m, nErr) {
+		if mw.options.publishStrategy.Failure(topic, m, nErr) {
 			fmt.Printf("retrying publish error, cause: message was dropped, retries exhausted {topic=%s, error=%s}\n", topic, nErr)
 
 			return nil
@@ -61,7 +69,7 @@ retry:
 		goto retry
 	}
 
-	mw.publishStrategy.Success(topic, m)
+	mw.options.publishStrategy.Success(topic, m)
 
 	return nil
 }
@@ -69,7 +77,7 @@ retry:
 func (mw middleware) Subscribe(ctx context.Context, topic pubsub.Topic, h pubsub.Handler, option ...pubsub.SubscribeOption) (pubsub.Subscription, error) {
 	s := &handler{
 		Handler:  h,
-		strategy: mw.deliverStrategy,
+		strategy: mw.options.deliverStrategy,
 	}
 
 	return mw.Broker.Subscribe(ctx, topic, s, option...)

--- a/middleware/retry/retry_test.go
+++ b/middleware/retry/retry_test.go
@@ -27,7 +27,7 @@ func TestPublishInterceptor(t *testing.T) {
 			Factor: 100 * time.Millisecond,
 			Max:    5 * time.Second,
 		})
-		broker = retry.NewRetryMiddleware(broker, strategy, strategy)
+		broker = retry.NewRetryMiddleware(broker, retry.WithPublishStrategy(strategy), retry.WithDeliverStrategy(strategy))
 
 		t.Run("WHEN underlying publishing fails", func(t *testing.T) {
 			err := broker.Publish(ctx, "topic", "message")
@@ -49,7 +49,7 @@ func TestPublishInterceptor(t *testing.T) {
 		broker := pubsub.Broker(mock)
 
 		strategy := retry.NewBreakerStrategy(5, time.Second)
-		broker = retry.NewRetryMiddleware(broker, strategy, strategy)
+		broker = retry.NewRetryMiddleware(broker, retry.WithPublishStrategy(strategy), retry.WithDeliverStrategy(strategy))
 
 		t.Run("WHEN underlying publishing fails 5 times in a row", func(t *testing.T) {
 			err := broker.Publish(ctx, "topic", "message")
@@ -91,7 +91,7 @@ func TestDeliveryInterception(t *testing.T) {
 		})
 
 		broker := memory.NewBroker()
-		broker = retry.NewRetryMiddleware(broker, strategy, strategy)
+		broker = retry.NewRetryMiddleware(broker, retry.WithPublishStrategy(strategy), retry.WithDeliverStrategy(strategy))
 		topic := pubsub.Topic("test")
 
 		h1 := pubsub.NewHandler(handler)
@@ -124,7 +124,7 @@ func TestDeliveryInterception(t *testing.T) {
 
 		strategy := retry.NewBreakerStrategy(4, time.Second)
 		broker := memory.NewBroker()
-		broker = retry.NewRetryMiddleware(broker, strategy, strategy)
+		broker = retry.NewRetryMiddleware(broker, retry.WithPublishStrategy(strategy), retry.WithDeliverStrategy(strategy))
 		topic := pubsub.Topic("test")
 
 		h1 := pubsub.NewHandler(handler)


### PR DESCRIPTION
- Pool: fixed functional options not being applied
- Retry:
  - added functional options
  - now by default, backoff strategies are used when not specified
  - added OnPublishError option to handle publish errors when retries are exhausted. By default a log is printed.